### PR TITLE
Enabling TLS support for older API levels

### DIFF
--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/TLSSocketFactory.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/TLSSocketFactory.java
@@ -1,0 +1,72 @@
+package cieloecommerce.sdk.ecommerce.request;
+
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * This will enable TLS 1.1 and 1.2 support.
+ *
+ * TLS 1.1 and TLS 1.2 Android support starts within API level 16+
+ * and it is enabled by default only from API level 20+.
+ */
+public class TLSSocketFactory extends SSLSocketFactory {
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    public TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(Socket socket) {
+        if(socket != null && (socket instanceof SSLSocket)) {
+            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+        }
+        return socket;
+    }
+}

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/AbstractSaleRequest.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/AbstractSaleRequest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -18,6 +20,7 @@ import javax.net.ssl.HttpsURLConnection;
 import cieloecommerce.sdk.Environment;
 import cieloecommerce.sdk.Merchant;
 import cieloecommerce.sdk.ecommerce.Sale;
+import cieloecommerce.sdk.ecommerce.request.TLSSocketFactory;
 
 /**
  * Abstraction to reuse most of the code that send and receive the HTTP messages.
@@ -28,6 +31,22 @@ public abstract class AbstractSaleRequest<T> extends AsyncTask<T, Void, Sale> {
     final Environment environment;
     private final Merchant merchant;
     private CieloRequestException exception;
+
+    static {
+        /* We need to do this in order to enable TLS support for some Android versions.
+         * TLS support has been enabled by default only after API level 20+.
+         * Support exists after API level 16+.
+         */
+        try {
+            if (android.os.Build.VERSION.SDK_INT < 20) {
+                HttpsURLConnection.setDefaultSSLSocketFactory(new TLSSocketFactory());
+            }
+        } catch (KeyManagementException e) {
+            Log.e("Cielo SDK", "Error enabling TLS support", e);
+        } catch (NoSuchAlgorithmException e) {
+            Log.e("Cielo SDK", "Error enabling TLS support", e);
+        }
+    }
 
     AbstractSaleRequest(Merchant merchant, Environment environment) {
         this.merchant = merchant;


### PR DESCRIPTION
Pessoal, estou abrindo esse PR pois tive um problema ao realizar requisições a partir de Androids mais antigos.
Percebi que antes da API level 20, o protocolo TLS não era habilitado por padrão. ([link documentação](https://developer.android.com/reference/javax/net/ssl/SSLSocket.html))
É preciso habilitar manualmente. Nesse PR eu faço isso.

Se tiverem alguma sugestão de mudança, sintam-se livres para fazê-la.

Parabéns por participarem da comunidade OpenSource. Espero poder colaborar com o repositório.