### PR TITLE
Update build.gradle and QuerySaleRequest.java

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
         versionName "1.0.0"

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QuerySaleRequest.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QuerySaleRequest.java
@@ -23,7 +23,7 @@ public class QuerySaleRequest extends AbstractSaleRequest<String> {
         String paymentId = params[0];
 
         try {
-            URL url = new URL(environment.getApiUrl() + "1/sales/" + paymentId);
+            URL url = new URL(environment.getApiQueryURL() + "1/sales/" + paymentId);
 
             sale = sendRequest("GET", url);
         } catch (IOException e) {


### PR DESCRIPTION
Although this decreases the number of version supported, it is important to know that the TLSv1.1and TLSv1.2 is supported only for API Level 16+ as mentioned here: https://developer.android.com/reference/javax/net/ssl/SSLSocket.html ...

...so, this PR updates the minSdkVersion supported by API-3.0-Android to 16+.

Also, it was mentioned [here](https://github.com/DeveloperCielo/API-3.0-Android/commit/baefa75c1387c4d01d7ab6810a3cf2cafc6315ac#diff-9349fe53f7b3e9b80bae48b72eee36e4) (see the comments on TLSSocketFactory class) for [that commit](https://github.com/DeveloperCielo/API-3.0-Android/commit/baefa75c1387c4d01d7ab6810a3cf2cafc6315ac).