### PR TITLE
Fix sale creation and sale update composition

### DIFF
--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/Card.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/Card.java
@@ -2,7 +2,7 @@ package cieloecommerce.sdk.ecommerce;
 
 import com.google.gson.annotations.SerializedName;
 
-public class CreditCard {
+public class Card {
     @SerializedName("CardNumber")
     private String cardNumber;
 
@@ -24,7 +24,7 @@ public class CreditCard {
     @SerializedName("CardToken")
     private String cardToken;
 
-    public CreditCard(String securityCode, String brand) {
+    public Card(String securityCode, String brand) {
         setSecurityCode(securityCode);
         setBrand(brand);
     }
@@ -33,7 +33,7 @@ public class CreditCard {
         return brand;
     }
 
-    public CreditCard setBrand(String brand) {
+    public Card setBrand(String brand) {
         this.brand = brand;
         return this;
     }
@@ -42,7 +42,7 @@ public class CreditCard {
         return cardNumber;
     }
 
-    public CreditCard setCardNumber(String cardNumber) {
+    public Card setCardNumber(String cardNumber) {
         this.cardNumber = cardNumber;
         return this;
     }
@@ -51,7 +51,7 @@ public class CreditCard {
         return cardToken;
     }
 
-    public CreditCard setCardToken(String cardToken) {
+    public Card setCardToken(String cardToken) {
         this.cardToken = cardToken;
         return this;
     }
@@ -60,7 +60,7 @@ public class CreditCard {
         return expirationDate;
     }
 
-    public CreditCard setExpirationDate(String expirationDate) {
+    public Card setExpirationDate(String expirationDate) {
         this.expirationDate = expirationDate;
         return this;
     }
@@ -69,7 +69,7 @@ public class CreditCard {
         return holder;
     }
 
-    public CreditCard setHolder(String holder) {
+    public Card setHolder(String holder) {
         this.holder = holder;
         return this;
     }
@@ -78,7 +78,7 @@ public class CreditCard {
         return saveCard;
     }
 
-    public CreditCard setSaveCard(boolean saveCard) {
+    public Card setSaveCard(boolean saveCard) {
         this.saveCard = saveCard;
         return this;
     }
@@ -87,7 +87,7 @@ public class CreditCard {
         return securityCode;
     }
 
-    public CreditCard setSecurityCode(String securityCode) {
+    public Card setSecurityCode(String securityCode) {
         this.securityCode = securityCode;
         return this;
     }

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/CieloEcommerce.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/CieloEcommerce.java
@@ -3,11 +3,7 @@ package cieloecommerce.sdk.ecommerce;
 import java.util.concurrent.ExecutionException;
 
 import cieloecommerce.sdk.Merchant;
-import cieloecommerce.sdk.ecommerce.request.AbstractSaleRequest;
-import cieloecommerce.sdk.ecommerce.request.CieloRequestException;
-import cieloecommerce.sdk.ecommerce.request.CreateSaleRequest;
-import cieloecommerce.sdk.ecommerce.request.QuerySaleRequest;
-import cieloecommerce.sdk.ecommerce.request.UpdateSaleRequest;
+import cieloecommerce.sdk.ecommerce.request.*;
 
 /**
  * The Cielo Ecommerce SDK front-end;
@@ -84,12 +80,12 @@ public class CieloEcommerce {
      * @throws CieloRequestException if anything gets wrong.
      * @see <a href="https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error Codes</a>
      */
-    public Sale cancelSale(String paymentId, Integer amount) throws ExecutionException, InterruptedException, CieloRequestException {
-        UpdateSaleRequest updateSaleRequest = new UpdateSaleRequest("void", merchant, environment);
+    public UpdateSaleResponse cancelSale(String paymentId, Integer amount) throws ExecutionException, InterruptedException, CieloRequestException {
+        UpdateSaleRequest updateSaleRequest = new UpdateSaleRequest(UpdateSaleRequest.UpdateType.VOID, merchant, environment);
 
         updateSaleRequest.setAmount(amount);
 
-        Sale sale = updateSaleRequest.execute(paymentId).get();
+        UpdateSaleResponse sale = updateSaleRequest.execute(paymentId).get();
 
         verifyThrownException(updateSaleRequest);
 
@@ -105,7 +101,7 @@ public class CieloEcommerce {
      * @throws CieloRequestException if anything gets wrong.
      * @see <a href="https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error Codes</a>
      */
-    public Sale cancelSale(String paymentId) throws ExecutionException, InterruptedException, CieloRequestException {
+    public UpdateSaleResponse cancelSale(String paymentId) throws ExecutionException, InterruptedException, CieloRequestException {
         return cancelSale(paymentId, null);
     }
 
@@ -120,13 +116,13 @@ public class CieloEcommerce {
      * @throws CieloRequestException if anything gets wrong.
      * @see <a href="https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error Codes</a>
      */
-    public Sale captureSale(String paymentId, Integer amount, Integer serviceTaxAmount) throws ExecutionException, InterruptedException, CieloRequestException {
-        UpdateSaleRequest updateSaleRequest = new UpdateSaleRequest("capture", merchant, environment);
+    public UpdateSaleResponse captureSale(String paymentId, Integer amount, Integer serviceTaxAmount) throws ExecutionException, InterruptedException, CieloRequestException {
+        UpdateSaleRequest updateSaleRequest = new UpdateSaleRequest(UpdateSaleRequest.UpdateType.CAPTURE, merchant, environment);
 
         updateSaleRequest.setAmount(amount);
         updateSaleRequest.setServiceTaxAmount(serviceTaxAmount);
 
-        Sale sale = updateSaleRequest.execute(paymentId).get();
+        UpdateSaleResponse sale = updateSaleRequest.execute(paymentId).get();
 
         verifyThrownException(updateSaleRequest);
 
@@ -143,7 +139,7 @@ public class CieloEcommerce {
      * @throws CieloRequestException if anything gets wrong.
      * @see <a href="https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error Codes</a>
      */
-    public Sale captureSale(String paymentId, Integer amount) throws ExecutionException, InterruptedException, CieloRequestException {
+    public UpdateSaleResponse captureSale(String paymentId, Integer amount) throws ExecutionException, InterruptedException, CieloRequestException {
         return captureSale(paymentId, amount, null);
     }
 
@@ -156,7 +152,7 @@ public class CieloEcommerce {
      * @throws CieloRequestException if anything gets wrong.
      * @see <a href="https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error Codes</a>
      */
-    public Sale captureSale(String paymentId) throws ExecutionException, InterruptedException, CieloRequestException {
+    public UpdateSaleResponse captureSale(String paymentId) throws ExecutionException, InterruptedException, CieloRequestException {
         return captureSale(paymentId, null, null);
     }
 

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
@@ -18,7 +18,9 @@ public class Payment {
     @SerializedName("RecurrentPayment")
     private RecurrentPayment recurrentPayment;
     @SerializedName("CreditCard")
-    private CreditCard creditCard;
+    private Card creditCard;
+    @SerializedName("DebitCard")
+    private Card debitCard;
     @SerializedName("Tid")
     private String tid;
     @SerializedName("ProofOfSale")
@@ -29,6 +31,8 @@ public class Payment {
     private String softDescriptor = "";
     @SerializedName("ReturnUrl")
     private String returnUrl;
+    @SerializedName("AuthenticationUrl")
+    private String authenticationUrl;
     @SerializedName("Provider")
     private Provider provider;
     @SerializedName("PaymentId")
@@ -79,11 +83,18 @@ public class Payment {
         this(amount, 1);
     }
 
-    public CreditCard creditCard(String securityCode, String brand) {
+    public Card creditCard(String securityCode, String brand) {
         setType(Type.CreditCard);
-        setCreditCard(new CreditCard(securityCode, brand));
+        setCreditCard(new Card(securityCode, brand));
 
         return getCreditCard();
+    }
+
+    public Card debitCard(String securityCode, String brand) {
+        setType(Type.DebitCard);
+        setDebitCard(new Card(securityCode, brand));
+
+        return getDebitCard();
     }
 
     public RecurrentPayment recurrentPayment(boolean authorizeNow) {
@@ -145,12 +156,25 @@ public class Payment {
         return this;
     }
 
-    public CreditCard getCreditCard() {
+    public Card getCard(){
+        return type == Type.CreditCard ? getCreditCard() : type == Type.DebitCard ? getDebitCard() : null;
+    }
+
+    public Card getCreditCard() {
         return creditCard;
     }
 
-    public Payment setCreditCard(CreditCard creditCard) {
+    public Payment setCreditCard(Card creditCard) {
         this.creditCard = creditCard;
+        return this;
+    }
+
+    public Card getDebitCard() {
+        return debitCard;
+    }
+
+    public Payment setDebitCard(Card debitCard) {
+        this.debitCard = debitCard;
         return this;
     }
 
@@ -259,6 +283,15 @@ public class Payment {
 
     public Payment setReturnUrl(String returnUrl) {
         this.returnUrl = returnUrl;
+        return this;
+    }
+
+    public String getAuthenticationUrl() {
+        return authenticationUrl;
+    }
+
+    public Payment setAuthenticationUrl(String authenticationUrl) {
+        this.authenticationUrl = authenticationUrl;
         return this;
     }
 

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/CreateSaleRequest.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/CreateSaleRequest.java
@@ -14,9 +14,9 @@ import cieloecommerce.sdk.ecommerce.Sale;
 /**
  * Create any kind of sale
  */
-public class CreateSaleRequest extends AbstractSaleRequest<Sale> {
+public class CreateSaleRequest extends AbstractSaleRequest<Sale, Sale> {
     public CreateSaleRequest(Merchant merchant, Environment environment) {
-        super(merchant, environment);
+        super(merchant, environment, Sale.class);
     }
 
     @Override

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QuerySaleRequest.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/QuerySaleRequest.java
@@ -12,9 +12,9 @@ import cieloecommerce.sdk.ecommerce.Sale;
 /**
  * Query a Sale by it's paymentId
  */
-public class QuerySaleRequest extends AbstractSaleRequest<String> {
+public class QuerySaleRequest extends AbstractSaleRequest<String, Sale> {
     public QuerySaleRequest(Merchant merchant, Environment environment) {
-        super(merchant, environment);
+        super(merchant, environment, Sale.class);
     }
 
     @Override

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/UpdateSaleRequest.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/UpdateSaleRequest.java
@@ -2,31 +2,29 @@ package cieloecommerce.sdk.ecommerce.request;
 
 import android.net.Uri;
 import android.util.Log;
+import cieloecommerce.sdk.Environment;
+import cieloecommerce.sdk.Merchant;
 
 import java.io.IOException;
 import java.net.URL;
 
-import cieloecommerce.sdk.Environment;
-import cieloecommerce.sdk.Merchant;
-import cieloecommerce.sdk.ecommerce.Sale;
-
 /**
  * Capture or cancel a Sale
  */
-public class UpdateSaleRequest extends AbstractSaleRequest<String> {
+public class UpdateSaleRequest extends AbstractSaleRequest<String, UpdateSaleResponse> {
     private final String type;
     private Integer amount;
     private Integer serviceTaxAmount;
 
     public UpdateSaleRequest(String type, Merchant merchant, Environment environment) {
-        super(merchant, environment);
+        super(merchant, environment, UpdateSaleResponse.class);
 
         this.type = type;
     }
 
     @Override
-    protected Sale doInBackground(String... params) {
-        Sale sale = null;
+    protected UpdateSaleResponse doInBackground(String... params) {
+        UpdateSaleResponse sale = null;
         String paymentId = params[0];
 
         try {
@@ -58,5 +56,12 @@ public class UpdateSaleRequest extends AbstractSaleRequest<String> {
 
     public void setServiceTaxAmount(Integer serviceTaxAmount) {
         this.serviceTaxAmount = serviceTaxAmount;
+    }
+
+    public static class UpdateType {
+
+        public static final String VOID = "void";
+        public static final String CAPTURE = "capture";
+
     }
 }

--- a/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/UpdateSaleResponse.java
+++ b/sdk/src/main/java/cieloecommerce/sdk/ecommerce/request/UpdateSaleResponse.java
@@ -1,0 +1,66 @@
+package cieloecommerce.sdk.ecommerce.request;
+
+import cieloecommerce.sdk.ecommerce.Link;
+import com.google.gson.annotations.SerializedName;
+
+public class UpdateSaleResponse {
+
+    @SerializedName("Status")
+    private Integer status;
+
+    @SerializedName("ReasonCode")
+    private Integer reasonCode;
+
+    @SerializedName("ReasonMessage")
+    private String reasonMessage;
+
+    @SerializedName("ProviderReturnCode")
+    private String providerReturnCode;
+
+    @SerializedName("ProviderReturnMessage")
+    private String providerReturnMessage;
+
+    @SerializedName("ReturnCode")
+    private String returnCode;
+
+    @SerializedName("ReturnMessage")
+    private String returnMessage;
+
+    @SerializedName("Links")
+    private Link[] links;
+
+    public UpdateSaleResponse() {
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public Integer getReasonCode() {
+        return reasonCode;
+    }
+
+    public String getReasonMessage() {
+        return reasonMessage;
+    }
+
+    public String getProviderReturnCode() {
+        return providerReturnCode;
+    }
+
+    public String getProviderReturnMessage() {
+        return providerReturnMessage;
+    }
+
+    public String getReturnCode() {
+        return returnCode;
+    }
+
+    public String getReturnMessage() {
+        return returnMessage;
+    }
+
+    public Link[] getLinks() {
+        return links;
+    }
+}


### PR DESCRIPTION
If I'm trying to create a debit card sale, the server won't accept my request if I send a 'creditCard' property inside my 'payment' property, it has to be named 'debitCard'. The way it is, the SDK don't allow that differentiation. So, with this PR, that differentiation will be possible. 

Also, the responses for each  creation and update of sales are different. So, I created the UpdateSaleResponse specification specifically for updates and I made the behavior of AbstractSaleRequest a little bit more generic to handle both creation and update.